### PR TITLE
Fix uncaught exception with exec result of null

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,9 +45,13 @@ switch (command) {
       let packagesWithLibdef = [];
       if (fs.existsSync(libdefDir)) {
         const libdefFiles = fs.readdirSync(libdefDir);
-        packagesWithLibdef = libdefFiles.map((file) => {
-          return LIBDEF_REGEX.exec(file)[1];
-        });
+        packagesWithLibdef = libdefFiles
+          .map((file) => {
+            const [, match] = LIBDEF_REGEX.exec(file) || [];
+
+            return match;
+          })
+          .filter(Boolean);
       } else {
         log('No existing community libdefs found. It is recommended to run `flow-typed install` first to pull in community libdefs.\n');
       }


### PR DESCRIPTION
Hello, big thanks for this tool!

I faced with this problem:
```sh
❯ node_modules/.bin/flow-scripts stub
Running flow-scripts in ...
node_modules/flow-scripts/index.js:49
          return LIBDEF_REGEX.exec(file)[1];
                                        ^

TypeError: Cannot read property '1' of null
    at libdefFiles.map (node_modules/flow-scripts/index.js:49:41)
```

It seems necessary to handle missed matches.

Thanks!