### PR TITLE
Blacklist default Flow typedef packages

### DIFF
--- a/lib/commands/stub.js
+++ b/lib/commands/stub.js
@@ -14,14 +14,16 @@ module.exports = function (args, options) {
   }
 
   const libdefDir = path.join(process.cwd(), dir, constants.DEFAULT_FLOW_TYPED_NPM_DIR);
-  let packagesWithLibdef = [];
+  let packagesWithLibdef = constants.DEFAULT_FLOW_TYPEDEFS;
   if (fs.existsSync(libdefDir)) {
     const libdefFiles = fs.readdirSync(libdefDir);
-    packagesWithLibdef = libdefFiles.map(file => {
+    const libdefs = libdefFiles.map(file => {
         const [, match] = constants.LIBDEF_REGEX.exec(file) || [];
         return match;
       })
       .filter(Boolean);
+      
+    packagesWithLibdef = packagesWithLibdef.concat(libdefs);
   } else {
     console.log('No existing community libdefs found. It is recommended to run ' +
      '`flow-typed install` first to pull in community libdefs.\n');

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -2,6 +2,8 @@ const config = {
   DEFAULT_FLOW_TYPED_DIR: 'flow-typed',
   DEFAULT_PACKAGE_DEP_LIBDEFS_FILENAME: 'package-dep-libdefs.js',
   DEFAULT_FLOW_TYPED_NPM_DIR: 'npm',
+  // These are bundled with Flow, so we do not generate stubs for them
+  DEFAULT_FLOW_TYPEDEFS = ['react', 'react-dom', 'react-dom/server'],
   FLOW_MARKER: '@flow',
   NOFLOW_MARKER: '@noflow',
   LIBDEF_REGEX: /^(.+)_v\w+\.\w+\.\w+\.js$/,


### PR DESCRIPTION
### Background 

`flow-scripts` is generating stubs for React, which is odd because React definitely has typedefs, but they don't appear to be in flow-typed's repo. After investigating, we found that Flow is bundled with the typedef for React: https://github.com/facebook/flow/blob/master/lib/react.js. 

(As an aside, this seems like a pretty terrible idea - notice all of the other bundled typedefs are for *native* APIs, and that by bundling you effectively tie Flow versions to React versions, but this is their problem, not ours)

### Approach 

We blacklist the modules listed in https://github.com/facebook/flow/blob/master/lib/react.js. Note that `react-native` is not listed in there, but is somehow has Flow typedefs, and doesn't appear in flow-typed either. This probably warrants further investigation, but I'm happy to fix this for `react` and `react-dom` for now. 

### References 

This fixes #7 