### PR TITLE
Fix typo in constants.js and testing setup

### DIFF
--- a/fixtures/package.json
+++ b/fixtures/package.json
@@ -1,6 +1,8 @@
 {
   "name": "flow-scripts-test-project",
-  "postinstall": "flow-scripts stub",
+  "scripts": {
+    "postinstall": "flow-scripts stub"
+  },
   "dependencies": {
     "babel-polyfill": "6.22.0",
     "classnames": "2.2.5",
@@ -23,6 +25,6 @@
   },
   "devDependencies": {
     "flow-bin": "0.38.0",
-    "flow-scripts": "0.1.0"
+    "flow-scripts": "file:.."
   }
 }

--- a/fixtures/yarn.lock
+++ b/fixtures/yarn.lock
@@ -25,6 +25,17 @@ babel-runtime@^6.22.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
+brace-expansion@^1.1.7:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
 classnames@2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
@@ -34,6 +45,10 @@ commander@^2.9.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -79,6 +94,28 @@ flow-scripts@0.1.0:
   dependencies:
     commander "^2.9.0"
 
+"flow-scripts@file:..":
+  version "0.3.0"
+  dependencies:
+    commander "^2.9.0"
+    glob "^7.1.2"
+    lodash "^4.17.4"
+
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+glob@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
@@ -103,6 +140,17 @@ iconv-lite@~0.4.13:
 immutable@^3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.1.tgz#200807f11ab0f72710ea485542de088075f68cd2"
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
 invariant@^2.0.0, invariant@^2.2.1:
   version "2.2.2"
@@ -153,7 +201,7 @@ lodash.keys@^3.1.2:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash@4.17.4, lodash@^4.2.0, lodash@^4.2.1:
+lodash@4.17.4, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -162,6 +210,12 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0:
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  dependencies:
+    brace-expansion "^1.1.7"
 
 moment@2.17.1:
   version "2.17.1"
@@ -177,6 +231,16 @@ node-fetch@^1.0.1:
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  dependencies:
+    wrappy "1"
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
 promise@^7.1.1:
   version "7.1.1"
@@ -320,3 +384,7 @@ warning@^3.0.0:
 whatwg-fetch@>=0.10.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.2.tgz#fe294d1d89e36c5be8b3195057f2e4bc74fc980e"
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"

--- a/lib/commands/stub.js
+++ b/lib/commands/stub.js
@@ -14,7 +14,7 @@ module.exports = function (args, options) {
   }
 
   const libdefDir = path.join(process.cwd(), dir, constants.DEFAULT_FLOW_TYPED_NPM_DIR);
-  let packagesWithLibdef = constants.DEFAULT_FLOW_TYPEDEFS;
+  let packagesWithLibdef = constants.DEFAULT_FLOW_LIBDEFS;
   if (fs.existsSync(libdefDir)) {
     const libdefFiles = fs.readdirSync(libdefDir);
     const libdefs = libdefFiles.map(file => {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -3,7 +3,7 @@ const config = {
   DEFAULT_PACKAGE_DEP_LIBDEFS_FILENAME: 'package-dep-libdefs.js',
   DEFAULT_FLOW_TYPED_NPM_DIR: 'npm',
   // These are bundled with Flow, so we do not generate stubs for them
-  DEFAULT_FLOW_TYPEDEFS = ['react', 'react-dom', 'react-dom/server'],
+  DEFAULT_FLOW_LIBDEFS: ['react', 'react-dom', 'react-dom/server'],
   FLOW_MARKER: '@flow',
   NOFLOW_MARKER: '@noflow',
   LIBDEF_REGEX: /^(.+)_v\w+\.\w+\.\w+\.js$/,


### PR DESCRIPTION
This PR fixes an embarrassing typo in the previous PR. It also improves and fixes the testing setup. 

- Fix typo: using `=` instead of `:` to set object property 
- Fix testing: `postinstall` should be under `scripts` in `package.json`, otherwise it won't be run automatically 
- Improve testing: Pull `flow-scripts` from `..` instead of npm, which would be somewhat difficult for testing since it requires the package to be published before it can be tested 